### PR TITLE
Add Spanish and English CV pages

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -22,6 +22,9 @@ main:
     
   - title: "CV"
     url: /cv/
+
+  - title: "CV Español"
+    url: /cv_es/
     
   - title: "Guide"
     url: /markdown/

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -1,49 +1,173 @@
 ---
 permalink: /
-title: "Academic Pages is a ready-to-fork GitHub Pages template for academic personal websites"
+title: "Curriculum Vitae"
 author_profile: true
-redirect_from: 
-  - /about/
-  - /about.html
 ---
 
-This is the front page of a website that is powered by the [Academic Pages template](https://github.com/academicpages/academicpages.github.io) and hosted on GitHub pages. [GitHub pages](https://pages.github.com) is a free service in which websites are built and hosted from code and data stored in a GitHub repository, automatically updating when a new commit is made to the repository. This template was forked from the [Minimal Mistakes Jekyll Theme](https://mmistakes.github.io/minimal-mistakes/) created by Michael Rose, and then extended to support the kinds of content that academics have: publications, talks, teaching, a portfolio, blog posts, and a dynamically-generated CV. You can fork [this template](https://github.com/academicpages/academicpages.github.io) right now, modify the configuration and markdown files, add your own PDFs and other content, and have your own site for free, with no ads!
+[English](#english) | [Espa\u00f1ol](#espanol)
 
-A data-driven personal website
-======
-Like many other Jekyll-based GitHub Pages templates, Academic Pages makes you separate the website's content from its form. The content & metadata of your website are in structured markdown files, while various other files constitute the theme, specifying how to transform that content & metadata into HTML pages. You keep these various markdown (.md), YAML (.yml), HTML, and CSS files in a public GitHub repository. Each time you commit and push an update to the repository, the [GitHub pages](https://pages.github.com/) service creates static HTML pages based on these files, which are hosted on GitHub's servers free of charge.
+![Foto](/cv/marksfotos3.jpg)
 
-Many of the features of dynamic content management systems (like Wordpress) can be achieved in this fashion, using a fraction of the computational resources and with far less vulnerability to hacking and DDoSing. You can also modify the theme to your heart's content without touching the content of your site. If you get to a point where you've broken something in Jekyll/HTML/CSS beyond repair, your markdown files describing your talks, publications, etc. are safe. You can rollback the changes or even delete the repository and start over - just be sure to save the markdown files! Finally, you can also write scripts that process the structured data on the site, such as [this one](https://github.com/academicpages/academicpages.github.io/blob/master/talkmap.ipynb) that analyzes metadata in pages about talks to display [a map of every location you've given a talk](https://academicpages.github.io/talkmap.html).
+Below you can find my curriculum information in both Spanish and English. Printable versions are available on the dedicated CV pages: [CV](/cv/) and [CV Espa\u00f1ol](/cv_es/).
 
-Getting started
-======
-1. Register a GitHub account if you don't have one and confirm your e-mail (required!)
-1. Fork [this template](https://github.com/academicpages/academicpages.github.io) by clicking the "Use this template" button in the top right. 
-1. Go to the repository's settings (rightmost item in the tabs that start with "Code", should be below "Unwatch"). Rename the repository "[your GitHub username].github.io", which will also be your website's URL.
-1. Set site-wide configuration and create content & metadata (see below -- also see [this set of diffs](http://archive.is/3TPas) showing what files were changed to set up [an example site](https://getorg-testacct.github.io) for a user with the username "getorg-testacct")
-1. Upload any files (like PDFs, .zip files, etc.) to the files/ directory. They will appear at https://[your GitHub username].github.io/files/example.pdf.  
-1. Check status by going to the repository settings, in the "GitHub pages" section
+## Espa\u00f1ol {#espanol}
 
-Site-wide configuration
-------
-The main configuration file for the site is in the base directory in [_config.yml](https://github.com/academicpages/academicpages.github.io/blob/master/_config.yml), which defines the content in the sidebars and other site-wide features. You will need to replace the default variables with ones about yourself and your site's github repository. The configuration file for the top menu is in [_data/navigation.yml](https://github.com/academicpages/academicpages.github.io/blob/master/_data/navigation.yml). For example, if you don't have a portfolio or blog posts, you can remove those items from that navigation.yml file to remove them from the header. 
+### Informaci\u00f3n Personal
 
-Create content & metadata
-------
-For site content, there is one markdown file for each type of content, which are stored in directories like _publications, _talks, _posts, _teaching, or _pages. For example, each talk is a markdown file in the [_talks directory](https://github.com/academicpages/academicpages.github.io/tree/master/_talks). At the top of each markdown file is structured data in YAML about the talk, which the theme will parse to do lots of cool stuff. The same structured data about a talk is used to generate the list of talks on the [Talks page](https://academicpages.github.io/talks), each [individual page](https://academicpages.github.io/talks/2012-03-01-talk-1) for specific talks, the talks section for the [CV page](https://academicpages.github.io/cv), and the [map of places you've given a talk](https://academicpages.github.io/talkmap.html) (if you run this [python file](https://github.com/academicpages/academicpages.github.io/blob/master/talkmap.py) or [Jupyter notebook](https://github.com/academicpages/academicpages.github.io/blob/master/talkmap.ipynb), which creates the HTML for the map based on the contents of the _talks directory).
+- **Nombre:** Calder\u00f3n Niqu\u00edn Marks Arturo
+- **Celular:** +51926685638
+- **Correo:** mcalderon@esan.edu.pe
 
-**Markdown generator**
+### Educaci\u00f3n
 
-The repository includes [a set of Jupyter notebooks](https://github.com/academicpages/academicpages.github.io/tree/master/markdown_generator
-) that converts a CSV containing structured data about talks or presentations into individual markdown files that will be properly formatted for the Academic Pages template. The sample CSVs in that directory are the ones I used to create my own personal website at stuartgeiger.com. My usual workflow is that I keep a spreadsheet of my publications and talks, then run the code in these notebooks to generate the markdown files, then commit and push them to the GitHub repository.
+- 2025 — *Emprendimiento innovador: de las ideas a la implementaci\u00f3n*, Mashav, Ministerio de Asuntos Exteriores de Israel, Haifa, Israel
+- 2024 — *Generative AI with Diffussion Models*, DLI NVIDIA, USA
+- 2023 — *Fundamentals of Deep Learning*, DLI NVIDIA, USA
+- 2019 — *Deep Learning Specialization*, Coursera, USA
+- 2018 — *Certificaci\u00f3n de Liderazgo y Coaching*, John Maxwell Team, USA
+- 2017 — *Diplomado en Fabricaci\u00f3n Digital*, FabAcademy, USA
+- 2014-2015 — *Maestr\u00eda en Ciencias con especialidad en Sistemas Inteligentes*, Tecnol\u00f3gico de Monterrey, M\u00e9xico
+- 2012 — *Ingeniero Inform\u00e1tico*, Universidad Nacional de Trujillo, Per\u00fa
+- 2007-2011 — *Bachiller en Ciencias de la Computaci\u00f3n*, Universidad Nacional de Trujillo, Per\u00fa
 
-How to edit your site's GitHub repository
-------
-Many people use a git client to create files on their local computer and then push them to GitHub's servers. If you are not familiar with git, you can directly edit these configuration and markdown files directly in the github.com interface. Navigate to a file (like [this one](https://github.com/academicpages/academicpages.github.io/blob/master/_talks/2012-03-01-talk-1.md) and click the pencil icon in the top right of the content preview (to the right of the "Raw | Blame | History" buttons). You can delete a file by clicking the trashcan icon to the right of the pencil icon. You can also create new files or upload files by navigating to a directory and clicking the "Create new file" or "Upload files" buttons. 
+### \u00c1reas de Inter\u00e9s
 
-Example: editing a markdown file for a talk
-![Editing a markdown file for a talk](/images/editing-talk.png)
+- Aprendizaje de m\u00e1quinas
+- Rob\u00f3tica creativa
+- Visi\u00f3n por computador
+- Algoritmos
 
-For more info
-------
-More info about configuring Academic Pages can be found in [the guide](https://academicpages.github.io/markdown/), the [growing wiki](https://github.com/academicpages/academicpages.github.io/wiki), and you can always [ask a question on GitHub](https://github.com/academicpages/academicpages.github.io/discussions). The [guides for the Minimal Mistakes theme](https://mmistakes.github.io/minimal-mistakes/docs/configuration/) (which this theme was forked from) might also be helpful.
+### Premios
+
+- Dic-2024 — *Premio a la Innovaci\u00f3n*, Universidad ESAN, ACM-Chatbot acad\u00e9mico
+- Nov-2012 — *Menci\u00f3n Honrosa*, ACM-ICPC South America/South Regional Contest, Entrenador
+- Nov-2011 — *Menci\u00f3n Honrosa*, ACM-ICPC South America/South Regional Contest, Participante
+- 2008 — *Primer puesto*, Concurso Programaci\u00f3n Semana de Ciencias de la Computaci\u00f3n, Universidad Nacional de Trujillo
+
+### Tesis de Maestr\u00eda
+
+**T\u00edtulo:** Object Detection in Real-time from 3D LIDAR data on Irregular Environment to Support Autonomous Navigation
+
+**Asesor:** Ph.D. Jos\u00e9 Luis Gordillo Moscoso
+
+**Descripci\u00f3n:** Desarrollo de una metodolog\u00eda para detecci\u00f3n de objetos en tiempo real utilizando un sensor LiDAR 3D para apoyar la navegaci\u00f3n aut\u00f3noma en entornos irregulares.
+
+### Tesis Profesional
+
+**T\u00edtulo:** Detecci\u00f3n de met\u00e1stasis de c\u00e1ncer mamario usando M\u00e1quinas de Soporte Vectorial a partir de datos de microarray
+
+**Asesores:** Msc. Jos\u00e9 Luis Peralta Luj\u00e1n y Ph.D.(c) Jorge Valverde Rebaza
+
+**Descripci\u00f3n:** Clasificaci\u00f3n de met\u00e1stasis de c\u00e1ncer mamario a partir de microarrays mediante un nuevo kernel aplicado a una m\u00e1quina de soporte de vectores.
+
+### Experiencia
+
+- 2024–actual — Director de Ingenier\u00eda de Software, Universidad ESAN, Lima, Per\u00fa
+- 2021–2023 — CEO, Codeplai Games SAC, Lima, Per\u00fa
+- 2017–actual — Profesor a tiempo completo, Universidad ESAN, Lima, Per\u00fa
+- 2018–2022 — CEO, Hypage LLC, Delaware, USA
+- 2018–2020 — Voluntariado de ayuda a ni\u00f1os en riesgo, Camino de Vida, Lima, Per\u00fa
+- 2016 — Profesor a tiempo parcial, Universidad ESAN, Lima, Per\u00fa
+- 2014–2015 — Asistente de Investigaci\u00f3n en Rob\u00f3tica, Tecnol\u00f3gico de Monterrey, Monterrey, M\u00e9xico
+- 2012–2013 — CEO, CLM Developers SAC, Trujillo, Per\u00fa
+- 2011 — Asistente de profesor, Universidad Nacional de Trujillo
+- 2011 — Programador de proyecto de investigaci\u00f3n, Universidad Nacional Santiago Ant\u00fanez de Mayolo, Huaraz, Per\u00fa
+- 2009–2012 — Coordinador Acad\u00e9mico, Sociedad de Estudiantes de Ciencia de la Computaci\u00f3n, Trujillo, Per\u00fa
+
+### Idiomas
+
+- Espa\u00f1ol — Fluido
+- Ingl\u00e9s — Avanzado
+
+### Habilidades T\u00e9cnicas
+
+- **Lenguajes de programaci\u00f3n:** Python, C/C++
+- **Frameworks:** Tensorflow, ROS y Qt5
+- **Plataformas hardware:** Arduino, ESP32
+- **Dise\u00f1o:** Kicad, Eagle, Inventor
+
+### Patentes
+
+- Dispositivo de entrenamiento inteligente basado en componentes interconectados a trav\u00e9s de aplicativo m\u00f3vil
+
+---
+
+## English {#english}
+
+### Personal Information
+
+- **Name:** Calder\u00f3n Niqu\u00edn Marks Arturo
+- **Cellphone:** +51926685638
+- **Email:** mcalderon@esan.edu.pe
+
+### Education
+
+- 2025 — *Innovative Entrepreneurship: from Ideas to Implementation*, Mashav, Ministry of Foreign Affairs of Israel, Haifa, Israel
+- 2024 — *Generative AI with Diffusion Models*, DLI NVIDIA, USA
+- 2023 — *Fundamentals of Deep Learning*, DLI NVIDIA, USA
+- 2019 — *Deep Learning Specialization*, Coursera, USA
+- 2018 — *Leadership and Coaching Certification*, John Maxwell Team, USA
+- 2017 — *Digital Fabrication Diploma*, FabAcademy, USA
+- 2014-2015 — *M.Sc. with specialization in Intelligent Systems*, Tecnol\u00f3gico de Monterrey, Mexico
+- 2012 — *Computer Engineer*, Universidad Nacional de Trujillo, Peru
+- 2007-2011 — *B.Sc. in Computer Science*, Universidad Nacional de Trujillo, Peru
+
+### Areas of Interest
+
+- Machine learning
+- Creative robotics
+- Computer vision
+- Algorithms
+
+### Awards
+
+- Dec-2024 — *Innovation Award*, Universidad ESAN, ACM-Academic Chatbot
+- Nov-2012 — *Honorable Mention*, ACM-ICPC South America/South Regional Contest, Coach
+- Nov-2011 — *Honorable Mention*, ACM-ICPC South America/South Regional Contest, Participant
+- 2008 — *First place*, Programming Contest Semana de Ciencias de la Computaci\u00f3n, Universidad Nacional de Trujillo
+
+### Master's Thesis
+
+**Title:** Object Detection in Real-time from 3D LIDAR data on Irregular Environment to Support Autonomous Navigation
+
+**Advisor:** Ph.D. Jos\u00e9 Luis Gordillo Moscoso
+
+**Description:** Development of a methodology for real-time object detection using a 3D LiDAR sensor to support autonomous navigation in irregular environments.
+
+### Undergraduate Thesis
+
+**Title:** Breast cancer metastasis detection using Support Vector Machines from microarray data
+
+**Advisors:** Msc. Jos\u00e9 Luis Peralta Luj\u00e1n and Ph.D.(c) Jorge Valverde Rebaza
+
+**Description:** Classification of breast cancer metastasis from microarrays with a new kernel applied to a support vector machine.
+
+### Experience
+
+- 2024–present — Director of Software Engineering, Universidad ESAN, Lima, Peru
+- 2021–2023 — CEO, Codeplai Games SAC, Lima, Peru
+- 2017–present — Full-time professor, Universidad ESAN, Lima, Peru
+- 2018–2022 — CEO, Hypage LLC, Delaware, USA
+- 2018–2020 — Volunteer helping at-risk children, Camino de Vida, Lima, Peru
+- 2016 — Part-time professor, Universidad ESAN, Lima, Peru
+- 2014–2015 — Research Assistant in Robotics, Tecnol\u00f3gico de Monterrey, Monterrey, Mexico
+- 2012–2013 — CEO, CLM Developers SAC, Trujillo, Peru
+- 2011 — Teaching assistant, Universidad Nacional de Trujillo
+- 2011 — Research project programmer, Universidad Nacional Santiago Ant\u00fanez de Mayolo, Huaraz, Peru
+- 2009–2012 — Academic Coordinator, Computer Science Students Society, Trujillo, Peru
+
+### Languages
+
+- Spanish — Fluent
+- English — Advanced
+
+### Technical Skills
+
+- **Programming languages:** Python, C/C++
+- **Frameworks:** Tensorflow, ROS and Qt5
+- **Hardware platforms:** Arduino, ESP32
+- **Design:** Kicad, Eagle, Inventor
+
+### Patents
+
+- Smart training device based on interconnected components through a mobile application

--- a/_pages/cv.md
+++ b/_pages/cv.md
@@ -3,62 +3,87 @@ layout: archive
 title: "CV"
 permalink: /cv/
 author_profile: true
-redirect_from:
-  - /resume
 ---
 
-{% include base_path %}
+![Photo](/cv/marksfotos3.jpg)
 
-Education
-======
-* Ph.D in Version Control Theory, GitHub University, 2018 (expected)
-* M.S. in Jekyll, GitHub University, 2014
-* B.S. in GitHub, GitHub University, 2012
+You can download the LaTeX source file [here](/files/cv_eng.tex). For the Spanish version, see [CV Español](/cv_es/).
 
-Work experience
-======
-* Spring 2024: Academic Pages Collaborator
-  * Github University
-  * Duties includes: Updates and improvements to template
-  * Supervisor: The Users
+## Personal Information
 
-* Fall 2015: Research Assistant
-  * Github University
-  * Duties included: Merging pull requests
-  * Supervisor: Professor Hub
+- **Name:** Calderón Niquín Marks Arturo
+- **Cellphone:** +51926685638
+- **Email:** mcalderon@esan.edu.pe
 
-* Summer 2015: Research Assistant
-  * Github University
-  * Duties included: Tagging issues
-  * Supervisor: Professor Git
-  
-Skills
-======
-* Skill 1
-* Skill 2
-  * Sub-skill 2.1
-  * Sub-skill 2.2
-  * Sub-skill 2.3
-* Skill 3
+## Education
 
-Publications
-======
-  <ul>{% for post in site.publications reversed %}
-    {% include archive-single-cv.html %}
-  {% endfor %}</ul>
-  
-Talks
-======
-  <ul>{% for post in site.talks reversed %}
-    {% include archive-single-talk-cv.html  %}
-  {% endfor %}</ul>
-  
-Teaching
-======
-  <ul>{% for post in site.teaching reversed %}
-    {% include archive-single-cv.html %}
-  {% endfor %}</ul>
-  
-Service and leadership
-======
-* Currently signed in to 43 different slack teams
+- 2025 — *Innovative Entrepreneurship: from Ideas to Implementation*, Mashav, Ministry of Foreign Affairs of Israel, Haifa, Israel
+- 2024 — *Generative AI with Diffusion Models*, DLI NVIDIA, USA
+- 2023 — *Fundamentals of Deep Learning*, DLI NVIDIA, USA
+- 2019 — *Deep Learning Specialization*, Coursera, USA
+- 2018 — *Leadership and Coaching Certification*, John Maxwell Team, USA
+- 2017 — *Digital Fabrication Diploma*, FabAcademy, USA
+- 2014-2015 — *M.Sc. with specialization in Intelligent Systems*, Tecnológico de Monterrey, Mexico
+- 2012 — *Computer Engineer*, Universidad Nacional de Trujillo, Peru
+- 2007-2011 — *B.Sc. in Computer Science*, Universidad Nacional de Trujillo, Peru
+
+## Areas of Interest
+
+- Machine learning
+- Creative robotics
+- Computer vision
+- Algorithms
+
+## Awards
+
+- Dec-2024 — *Innovation Award*, Universidad ESAN, ACM-Academic Chatbot
+- Nov-2012 — *Honorable Mention*, ACM-ICPC South America/South Regional Contest, Coach
+- Nov-2011 — *Honorable Mention*, ACM-ICPC South America/South Regional Contest, Participant
+- 2008 — *First place*, Programming Contest Semana de Ciencias de la Computación, Universidad Nacional de Trujillo
+
+## Master's Thesis
+
+**Title:** Object Detection in Real-time from 3D LIDAR data on Irregular Environment to Support Autonomous Navigation
+
+**Advisor:** Ph.D. José Luis Gordillo Moscoso
+
+**Description:** Development of a methodology for real-time object detection using a 3D LiDAR sensor to support autonomous navigation in irregular environments.
+
+## Undergraduate Thesis
+
+**Title:** Breast cancer metastasis detection using Support Vector Machines from microarray data
+
+**Advisors:** Msc. José Luis Peralta Luján and Ph.D.(c) Jorge Valverde Rebaza
+
+**Description:** Classification of breast cancer metastasis from microarrays with a new kernel applied to a support vector machine.
+
+## Experience
+
+- 2024–present — Director of Software Engineering, Universidad ESAN, Lima, Peru
+- 2021–2023 — CEO, Codeplai Games SAC, Lima, Peru
+- 2017–present — Full-time professor, Universidad ESAN, Lima, Peru
+- 2018–2022 — CEO, Hypage LLC, Delaware, USA
+- 2018–2020 — Volunteer helping at-risk children, Camino de Vida, Lima, Peru
+- 2016 — Part-time professor, Universidad ESAN, Lima, Peru
+- 2014–2015 — Research Assistant in Robotics, Tecnológico de Monterrey, Monterrey, Mexico
+- 2012–2013 — CEO, CLM Developers SAC, Trujillo, Peru
+- 2011 — Teaching assistant, Universidad Nacional de Trujillo
+- 2011 — Research project programmer, Universidad Nacional Santiago Antúnez de Mayolo, Huaraz, Peru
+- 2009–2012 — Academic Coordinator, Computer Science Students Society, Trujillo, Peru
+
+## Languages
+
+- Spanish — Fluent
+- English — Advanced
+
+## Technical Skills
+
+- **Programming languages:** Python, C/C++
+- **Frameworks:** Tensorflow, ROS and Qt5
+- **Hardware platforms:** Arduino, ESP32
+- **Design:** Kicad, Eagle, Inventor
+
+## Patents
+
+- Smart training device based on interconnected components through a mobile application
+

--- a/_pages/cv_es.md
+++ b/_pages/cv_es.md
@@ -1,0 +1,92 @@
+---
+layout: archive
+title: "CV Español"
+permalink: /cv_es/
+author_profile: true
+
+---
+
+Para la versión en inglés, visita [CV](/cv/).
+
+![Foto](/cv/marksfotos3.jpg)
+
+Puedes descargar el archivo fuente en LaTeX [aquí](/files/cv_esp.tex).
+
+## Información Personal
+
+- **Nombre:** Calderón Niquín Marks Arturo
+- **Celular:** +51926685638
+- **Correo:** mcalderon@esan.edu.pe
+
+## Educación
+
+- 2025 — *Emprendimiento innovador: de las ideas a la implementación*, Mashav, Ministerio de Asuntos Exteriores de Israel, Haifa, Israel
+- 2024 — *Generative AI with Diffussion Models*, DLI NVIDIA, USA
+- 2023 — *Fundamentals of Deep Learning*, DLI NVIDIA, USA
+- 2019 — *Deep Learning Specialization*, Coursera, USA
+- 2018 — *Certificación de Liderazgo y Coaching*, John Maxwell Team, USA
+- 2017 — *Diplomado en Fabricación Digital*, FabAcademy, USA
+- 2014-2015 — *Maestría en Ciencias con especialidad en Sistemas Inteligentes*, Tecnológico de Monterrey, México
+- 2012 — *Ingeniero Informático*, Universidad Nacional de Trujillo, Perú
+- 2007-2011 — *Bachiller en Ciencias de la Computación*, Universidad Nacional de Trujillo, Perú
+
+## Áreas de Interés
+
+- Aprendizaje de máquinas
+- Robótica creativa
+- Visión por computador
+- Algoritmos
+
+## Premios
+
+- Dic-2024 — *Premio a la Innovación*, Universidad ESAN, ACM-Chatbot académico
+- Nov-2012 — *Mención Honrosa*, ACM-ICPC South America/South Regional Contest, Entrenador
+- Nov-2011 — *Mención Honrosa*, ACM-ICPC South America/South Regional Contest, Participante
+- 2008 — *Primer puesto*, Concurso Programación Semana de Ciencias de la Computación, Universidad Nacional de Trujillo
+
+## Tesis de Maestría
+
+**Título:** Object Detection in Real-time from 3D LIDAR data on Irregular Environment to Support Autonomous Navigation
+
+**Asesor:** Ph.D. José Luis Gordillo Moscoso
+
+**Descripción:** Desarrollo de una metodología para detección de objetos en tiempo real utilizando un sensor LiDAR 3D para apoyar la navegación autónoma en entornos irregulares.
+
+## Tesis Profesional
+
+**Título:** Detección de metástasis de cáncer mamario usando Máquinas de Soporte Vectorial a partir de datos de microarray
+
+**Asesores:** Msc. José Luis Peralta Luján y Ph.D.(c) Jorge Valverde Rebaza
+
+**Descripción:** Clasificación de metástasis de cáncer mamario a partir de microarrays mediante un nuevo kernel aplicado a una máquina de soporte de vectores.
+
+## Experiencia
+
+- 2024–actual — Director de Ingeniería de Software, Universidad ESAN, Lima, Perú
+- 2021–2023 — CEO, Codeplai Games SAC, Lima, Perú
+- 2017–actual — Profesor a tiempo completo, Universidad ESAN, Lima, Perú
+- 2018–2022 — CEO, Hypage LLC, Delaware, USA
+- 2018–2020 — Voluntariado de ayuda a niños en riesgo, Camino de Vida, Lima, Perú
+- 2016 — Profesor a tiempo parcial, Universidad ESAN, Lima, Perú
+- 2014–2015 — Asistente de Investigación en Robótica, Tecnológico de Monterrey, Monterrey, México
+- 2012–2013 — CEO, CLM Developers SAC, Trujillo, Perú
+- 2011 — Asistente de profesor, Universidad Nacional de Trujillo
+- 2011 — Programador de proyecto de investigación, Universidad Nacional Santiago Antúnez de Mayolo, Huaraz, Perú
+- 2009–2012 — Coordinador Académico, Sociedad de Estudiantes de Ciencia de la Computación, Trujillo, Perú
+
+## Idiomas
+
+- Español — Fluido
+- Inglés — Avanzado
+
+## Habilidades Técnicas
+
+- **Lenguajes de programación:** Python, C/C++
+- **Frameworks:** Tensorflow, ROS y Qt5
+- **Plataformas hardware:** Arduino, ESP32
+- **Diseño:** Kicad, Eagle, Inventor
+
+## Patentes
+
+- Dispositivo de entrenamiento inteligente basado en componentes interconectados a través de aplicativo móvil
+

--- a/cv/cv_eng.tex
+++ b/cv/cv_eng.tex
@@ -1,0 +1,88 @@
+\documentclass[11pt,a4paper,sans]{moderncv}
+\moderncvstyle{casual}
+\moderncvcolor{blue}
+\usepackage[utf8]{inputenc}
+\usepackage[scale=0.75,a4paper]{geometry}
+\usepackage[english]{babel}
+\usepackage{apacite}
+
+%------------------------------------------------------------------------------
+%            personal data
+%------------------------------------------------------------------------------
+\firstname{Marks}
+\familyname{Calder\'on Niqu\'{i}n}
+\address{Jr Los Forestales 120}{Lima}{Per\'u}
+\mobile{+51926685638}
+\email{mcalderon@esan.edu.pe}
+\photo[64pt][0.4pt]{marksfotos3}
+
+\begin{document}
+\makecvtitle
+
+\section{Personal Information}
+\cvitem{Name}{Calder\'on Niqu\'in Marks Arturo}
+\cvitem{Cellphone}{+51926685638}
+\cvitem{E-mail}{mcalderon@esan.edu.pe}
+
+\section{Education}
+\cventry{2025}{Innovative Entrepreneurship: from Ideas to Implementation}{Mashav, Ministry of Foreign Affairs of Israel}{Haifa}{Israel}{}
+\cventry{2024}{Generative AI with Diffusion Models}{DLI NVIDIA}{USA}{}{}
+\cventry{2023}{Fundamentals of Deep Learning}{DLI NVIDIA}{USA}{}{}
+\cventry{2019}{Deep Learning Specialization}{Coursera}{USA}{}{}
+\cventry{2018}{Leadership and Coaching Certification}{John Maxwell Team}{USA}{}{}
+\cventry{2017}{Digital Fabrication Diploma}{FabAcademy}{USA}{}{}
+\cventry{2014-2015}{M.Sc. with specialization in Intelligent Systems}{Tecnol\'ogico de Monterrey}{M\'exico}{}{}
+\cventry{2012}{Computer Engineer}{Universidad Nacional de Trujillo}{Per\'u}{}{}
+\cventry{2007--2011}{B.Sc. in Computer Science}{Universidad Nacional de Trujillo}{Per\'u}{}{}
+
+\section{Areas of Interest}
+\cvlistitem{Machine learning}
+\cvlistitem{Creative robotics}
+\cvlistitem{Computer vision}
+\cvlistitem{Algorithms}
+
+\section{Awards}
+\cventry{Dec-2024}{Innovation Award}{Universidad ESAN}{Participant}{ACM-Academic Chatbot}{}
+\cventry{Nov-2012}{Honorable Mention}{ACM International Collegiate Programming Contest South America/South Regional Contest}{Coach}{ACM-ICPC}{}
+\cventry{Nov-2011}{Honorable Mention}{ACM International Collegiate Programming Contest South America/South Regional Contest}{Participant}{ACM-ICPC}{}
+\cventry{2008}{First place}{Programming Contest, Week of Computer Science}{Trujillo}{Universidad Nacional de Trujillo}{}
+
+\section{Master's Thesis}
+\cvitem{Title}{Object Detection in Real-time from 3D LIDAR data on Irregular Environment to Support Autonomous Navigation}
+\cvitem{Advisor}{Ph.D. Jos\'e Luis Gordillo Moscoso}
+\cvitem{Description}{Development of a methodology for real-time object detection using a 3D LiDAR sensor to support autonomous navigation in irregular environments.}
+
+\section{Undergraduate Thesis}
+\cvitem{Title}{Breast cancer metastasis detection using Support Vector Machines from microarray data}
+\cvitem{Advisors}{Msc. Jos\'e Luis Peralta Luj\'an and Ph.D.(c) Jorge Valverde Rebaza}
+\cvitem{Description}{Classification of breast cancer metastasis from microarrays with a new kernel applied to a support vector machine.}
+
+\section{Experience}
+\cventry{2024--present}{Director of Software Engineering}{Universidad ESAN}{Lima}{Per\'u}{}
+\cventry{2021--2023}{CEO}{Codeplai Games SAC}{Lima}{Per\'u}{}
+\cventry{2017--present}{Full-time professor}{Universidad ESAN}{Lima}{Per\'u}{}
+\cventry{2018--2022}{CEO}{Hypage LLC}{Delaware}{USA}{}
+\cventry{2018--2020}{Volunteer helping at-risk children}{Camino de Vida}{Lima}{Per\'u}{}
+\cventry{2016}{Part-time professor}{Universidad ESAN}{Lima}{Per\'u}{}
+\cventry{2014-2015}{Research Assistant in Robotics}{Tecnol\'ogico de Monterrey}{Monterrey}{M\'exico}{}
+\cventry{2012-2013}{CEO}{CLM Developers SAC}{Trujillo}{Per\'u}{}
+\cventry{2011}{Teaching assistant}{Universidad Nacional de Trujillo}{}{}{}
+\cventry{2011}{Research project programmer}{Universidad Nacional Santiago Ant\'unez de Mayolo}{Huaraz}{Per\'u}{}
+\cventry{2009-2012}{Academic Coordinator}{Computer Science Students Society}{Trujillo}{Per\'u}{}
+
+\section{Languages}
+\cvitemwithcomment{Spanish}{Fluent}{}
+\cvitemwithcomment{English}{Advanced}{}
+
+\section{Technical Skills}
+\cvdoubleitem{Programming Languages}{Python, C/C++}{Frameworks}{Tensorflow, ROS, Qt5}
+\cvdoubleitem{Hardware Platforms}{Arduino, ESP32}{Design}{Kicad, Eagle, Inventor}
+
+\section{Patents}
+\cvitem{Completed}{Smart training device based on interconnected components through a mobile application}
+
+\nocite{*}
+\bibliographystyle{chronological}
+\bibliography{publicaciones}
+
+\end{document}

--- a/files/cv_eng.tex
+++ b/files/cv_eng.tex
@@ -1,0 +1,88 @@
+\documentclass[11pt,a4paper,sans]{moderncv}
+\moderncvstyle{casual}
+\moderncvcolor{blue}
+\usepackage[utf8]{inputenc}
+\usepackage[scale=0.75,a4paper]{geometry}
+\usepackage[english]{babel}
+\usepackage{apacite}
+
+%------------------------------------------------------------------------------
+%            personal data
+%------------------------------------------------------------------------------
+\firstname{Marks}
+\familyname{Calder\'on Niqu\'{i}n}
+\address{Jr Los Forestales 120}{Lima}{Per\'u}
+\mobile{+51926685638}
+\email{mcalderon@esan.edu.pe}
+\photo[64pt][0.4pt]{marksfotos3}
+
+\begin{document}
+\makecvtitle
+
+\section{Personal Information}
+\cvitem{Name}{Calder\'on Niqu\'in Marks Arturo}
+\cvitem{Cellphone}{+51926685638}
+\cvitem{E-mail}{mcalderon@esan.edu.pe}
+
+\section{Education}
+\cventry{2025}{Innovative Entrepreneurship: from Ideas to Implementation}{Mashav, Ministry of Foreign Affairs of Israel}{Haifa}{Israel}{}
+\cventry{2024}{Generative AI with Diffusion Models}{DLI NVIDIA}{USA}{}{}
+\cventry{2023}{Fundamentals of Deep Learning}{DLI NVIDIA}{USA}{}{}
+\cventry{2019}{Deep Learning Specialization}{Coursera}{USA}{}{}
+\cventry{2018}{Leadership and Coaching Certification}{John Maxwell Team}{USA}{}{}
+\cventry{2017}{Digital Fabrication Diploma}{FabAcademy}{USA}{}{}
+\cventry{2014-2015}{M.Sc. with specialization in Intelligent Systems}{Tecnol\'ogico de Monterrey}{M\'exico}{}{}
+\cventry{2012}{Computer Engineer}{Universidad Nacional de Trujillo}{Per\'u}{}{}
+\cventry{2007--2011}{B.Sc. in Computer Science}{Universidad Nacional de Trujillo}{Per\'u}{}{}
+
+\section{Areas of Interest}
+\cvlistitem{Machine learning}
+\cvlistitem{Creative robotics}
+\cvlistitem{Computer vision}
+\cvlistitem{Algorithms}
+
+\section{Awards}
+\cventry{Dec-2024}{Innovation Award}{Universidad ESAN}{Participant}{ACM-Academic Chatbot}{}
+\cventry{Nov-2012}{Honorable Mention}{ACM International Collegiate Programming Contest South America/South Regional Contest}{Coach}{ACM-ICPC}{}
+\cventry{Nov-2011}{Honorable Mention}{ACM International Collegiate Programming Contest South America/South Regional Contest}{Participant}{ACM-ICPC}{}
+\cventry{2008}{First place}{Programming Contest, Week of Computer Science}{Trujillo}{Universidad Nacional de Trujillo}{}
+
+\section{Master's Thesis}
+\cvitem{Title}{Object Detection in Real-time from 3D LIDAR data on Irregular Environment to Support Autonomous Navigation}
+\cvitem{Advisor}{Ph.D. Jos\'e Luis Gordillo Moscoso}
+\cvitem{Description}{Development of a methodology for real-time object detection using a 3D LiDAR sensor to support autonomous navigation in irregular environments.}
+
+\section{Undergraduate Thesis}
+\cvitem{Title}{Breast cancer metastasis detection using Support Vector Machines from microarray data}
+\cvitem{Advisors}{Msc. Jos\'e Luis Peralta Luj\'an and Ph.D.(c) Jorge Valverde Rebaza}
+\cvitem{Description}{Classification of breast cancer metastasis from microarrays with a new kernel applied to a support vector machine.}
+
+\section{Experience}
+\cventry{2024--present}{Director of Software Engineering}{Universidad ESAN}{Lima}{Per\'u}{}
+\cventry{2021--2023}{CEO}{Codeplai Games SAC}{Lima}{Per\'u}{}
+\cventry{2017--present}{Full-time professor}{Universidad ESAN}{Lima}{Per\'u}{}
+\cventry{2018--2022}{CEO}{Hypage LLC}{Delaware}{USA}{}
+\cventry{2018--2020}{Volunteer helping at-risk children}{Camino de Vida}{Lima}{Per\'u}{}
+\cventry{2016}{Part-time professor}{Universidad ESAN}{Lima}{Per\'u}{}
+\cventry{2014-2015}{Research Assistant in Robotics}{Tecnol\'ogico de Monterrey}{Monterrey}{M\'exico}{}
+\cventry{2012-2013}{CEO}{CLM Developers SAC}{Trujillo}{Per\'u}{}
+\cventry{2011}{Teaching assistant}{Universidad Nacional de Trujillo}{}{}{}
+\cventry{2011}{Research project programmer}{Universidad Nacional Santiago Ant\'unez de Mayolo}{Huaraz}{Per\'u}{}
+\cventry{2009-2012}{Academic Coordinator}{Computer Science Students Society}{Trujillo}{Per\'u}{}
+
+\section{Languages}
+\cvitemwithcomment{Spanish}{Fluent}{}
+\cvitemwithcomment{English}{Advanced}{}
+
+\section{Technical Skills}
+\cvdoubleitem{Programming Languages}{Python, C/C++}{Frameworks}{Tensorflow, ROS, Qt5}
+\cvdoubleitem{Hardware Platforms}{Arduino, ESP32}{Design}{Kicad, Eagle, Inventor}
+
+\section{Patents}
+\cvitem{Completed}{Smart training device based on interconnected components through a mobile application}
+
+\nocite{*}
+\bibliographystyle{chronological}
+\bibliography{publicaciones}
+
+\end{document}

--- a/files/cv_esp.tex
+++ b/files/cv_esp.tex
@@ -1,0 +1,116 @@
+\documentclass[11pt,a4paper,sans]{moderncv}        % possible options include font size ('10pt', '11pt' and '12pt'), paper size ('a4paper', 'letterpaper', 'a5paper', 'legalpaper', 'executivepaper' and 'landscape') and font family ('sans' and 'roman')
+\moderncvstyle{casual}                             % style options are 'casual' (default), 'classic', 'oldstyle' and 'banking'
+\moderncvcolor{blue}                               % color options 'blue' (default), 'orange', 'green', 'red', 'purple', 'grey' and 'black'
+%\nopagenumbers{}                                  % uncomment to suppress automatic page numbering for CVs longer than one page
+\usepackage[utf8]{inputenc}                       % if you are not using xelatex ou lualatex, replace by the encoding you are using
+\usepackage[scale=0.75,a4paper]{geometry}
+\usepackage{babel}
+\usepackage{apacite}
+
+
+%----------------------------------------------------------------------------------
+%            personal data
+%----------------------------------------------------------------------------------
+\firstname{Marks}
+\familyname{Calder\'on Niqu\'{i}n}
+%\title{Resumé title}                               % optional, remove/comment the line if not wanted
+\address{Jr Los Forestales 120}{Lima}{Per\'u}         % optional, remove/comment the line if not wanted; the "country" arguments can be omitted or provided empty
+\mobile{+51926685638}                          % optional, remove/comment the line if not wanted
+%\phone{phone number}                           % optional, remove/comment the line if not wanted
+%\fax{fax number}                             % optional, remove/comment the line if not wanted
+\email{mcalderon@esan.edu.pe}                               % optional, remove/comment the line if not wanted
+%\homepage{home page}                         % optional, remove/comment the line if not wanted
+%\extrainfo{additional information}                 % optional, remove/comment the line if not wanted
+ \photo[64pt][0.4pt]{marksfotos3}                       % optional, uncomment the line if wanted; '64pt' is the height the picture must be resized to, 0.4pt is the thickness of the frame around it (put it to 0pt for no frame) and 'picture' is the name of the picture file
+%\quote{some quote}                                 % optional, remove/comment the line if not wanted
+%
+\begin{document}
+%-----       resume       ---------------------------------------------------------
+\makecvtitle
+\section{Informaci\'on Personal}
+\cvitem{Nombres}{Calder\'on Niquin Marks Arturo}
+%\cvitem{Edad}{30}
+\cvitem{Celular}{+51926685638}
+\cvitem{E-mail}{mcalderon@esan.edu.pe}
+\section{Educaci\'on}
+\cventry{2025}{ Emprendimiento innovador: de las ideas a la implementación}{Mashav, Ministerio de Asuntos Exteriores de Israel}{Haifa}{Israel}{}
+
+\cventry{2024}{Generative AI with Difussion Models}{DLI NVIDIA}{USA}{}{}
+\cventry{2023}{Fundamentals of Deep Learning}{DLI NVIDIA}{USA}{}{}
+\cventry{2019}{Deep Learning Specialization}{Coursera}{USA}{}{}
+\cventry{2019}{Deep Learning Specialization}{Coursera}{USA}{}{}
+\cventry{2018}{Certificaci\'on de Liderazgo y Coaching}{John Maxwell Team}{USA}{}{}
+\cventry{2017}{Diplomado en Fabricaci\'on Digital}{FabAcademy}{USA}{}{}
+\cventry{2014-2015}{Maestria en Ciencias con especialidad en Sistemas Inteligentes}{Tecnol\'ogico de Monterrey, M\'exico}{}{}{}  % arguments 3 to 6 can be left empty
+\cventry{2012}{Ingeniero Inform\'atico}{Universidad Nacional de Trujillo, Per\'u}{}{}{}
+\cventry{2007--2011}{Bachiller en Ciencias de la Computaci\'on}{Universidad Nacional de Trujillo, Per\'u}{}{}{}
+
+\section{\'Areas de Inter\'es}
+\cvlistitem{Aprendizaje de m\'aquinas}
+	\cvlistitem{Rob\'otica creativa}
+	\cvlistitem{Visi\'on por computador}
+    \cvlistitem{Algoritmos}
+\section{Premios}
+\cventry{Dic-2024}{Premio a la Innovaci\'on}{Universidad ESAN}{Participanten}{ACM-Chatbot academico}{}
+\cventry{Nov-2012}{Menci\'on Honrosa}{ACM - International Collegiate Programming Contest
+(ACM-ICPC) South America/South Regional Contest}{Entrenador}{ACM-ICPC}{}
+\cventry{Nov-2011}{Menci\'on Honrosa}{ACM - International Collegiate Programming Contest
+	(ACM-ICPC) South America/South Regional Contest}{Participante}{ACM-ICPC}{}
+\cventry{2008}{Primer puesto}{Concurso Programaci\'on Semana de Ciencias de la Computaci\'on}{Trujillo}{Universidad Nacional de Trujillo}{}
+\section{Tesis de Maestr\'{i}a}
+\cvitem{Titulo}{Object Detection  in Real-time from 3D LIDAR data on Irregular Environment to Support Autonomous Navigation}
+\cvitem{Asesor}{Ph.D. Jos\'e Luis Gordillo Moscoso}
+\cvitem{Descripci\'on}{The major objective of this study is to develop a methodology for object detection in real-time using a 3D perception LiDAR sensor to support autonomous navigation in irregular environments. Our proposed methodology is composed of six stages, uses the sensor’s rotational feature and avoids non-neighborhood analysis to achieve a real-time processing all stages. The generated objects using our methods have complex shape so that they are abstracted with a new representation which project over an occupancy grid  minimize the projection area of each object. The last stage want to create an optimal path from initial position to target point using the occupancy grid, this route can support to future autonomous navigation robot. Finally all objectives were achievement and experimented on different scenarios. The algorithms created and implemented had low computational cost in order the real-time processing.}
+\section{Tesis Profesional}
+\cvitem{Titulo}{Detecci\'on de met\'astasis de c\'ancer
+mamario usando M\'aquinas de Soporte
+Vectorial a partir de datos de microarray}
+\cvitem{Asesores}{Msc. José Luis Peralta Luján and Ph.D.(c) Jorge Valverde Rebaza}
+\cvitem{Descripci\'on}{El prop\'osito del proyecto fue clasificar met\'astasis de c\'ancer mamario a partir de datos de microarrays, para lo cual se desarrollo un nuevo kernel que fue empleado con una m\'aquina de soporte de vectores. Los resultados obtenidos muestran una media por encima del 85$\%$ de precisi\'on. As\'{i} el metodo podria ser aplicado en un contexto local. }
+
+
+\section{Experiencia}
+\cventry{2024 -actual}{Director de Ingenieria de Software}{Universidad ESAN}{Lima}{Peru}{}
+\cventry{2021 -2023}{CEO}{Codeplai Games SAC}{Lima}{Peru}{}
+
+\cventry{2017--actual}{Profesor a tiempo completo}{Universidad ESAN}{Lima, Per\'u}{}{}
+
+\cventry{2018 - 2022}{CEO}{Hypage LLC}{Delaware}{USA}{}
+\cventry{2018 - 2020}{Voluntariado de ayuda a ni\~nos en riesgo}{Camino de Vida}{La Victoria}{Lima}{Per\'u}
+\cventry{2016}{Profesor a tiempo parcial}{Universidad ESAN}{Lima, Per\'u}{}{}
+\cventry{2014-2015}{Asistente de Investigaci\'on en Rob\'otica}{Tecnol\'ogico de Monterrey}{Monterrey, M\'exico}{}{}
+\cventry{2012-2013}{CEO}{CLM Developers SAC}{Trujillo, Per\'u}{}{}
+\cventry{2011}{Asistente de profesor}{Departamento de Inform\'atica, Universidad Nacional de Trujillo}{}{}{}
+\cventry{2011}{Programador de proyecto de investigaci\'on}{Universidad Nacional Santiago Antunez de Mayolo}{Huaraz, Per\'u}{Fuzzy Multiple Objective Linear Programming
+and its application to make decision in the fertilizer planning on farmland }{}
+\cventry{2009-2012}{Coordinador Acad\'emico}{Sociedad de Estudiantes de Ciencia de la Computaci\'on}{Trujillo, Per\'u}{}{}
+\section{Idiomas}
+\cvitemwithcomment{Espa\~nol}{Fluido}{}
+\cvitemwithcomment{Ingl\'es}{Avanzado}{}
+
+\section{Habilidades T\'ecnicas}
+\cvdoubleitem{Lenguajes de programaci\'on}{Python, C/C++}{Frameworks}{Tensorflow,ROS y Qt5}
+\cvdoubleitem{Plataformas hardware}{Arduino, ESP32}{Dise\~no}{Kicad, Eagle, Inventor}
+
+\section{Patentes}
+\cvitem{Culminado}{Dispositivo de entrenamiento inteligente basado en componentes interconectados a través de aplicativo móvil}
+%\cvitem{Hobby 2}{Leer}
+%\cvitem{Hobby 3}{Cocinar}
+
+
+%\section{References}
+%\begin{cvcolumns}
+ % \cvcolumn{Category 1}{Comment}
+ % \cvcolumn{Category 2}{Comment}
+ % \cvcolumn{Category 3}{Comment}
+%\end{cvcolumns}
+
+%-----       letter       ---------------------------------------------------------
+% recipient data
+
+\nocite{*}
+\bibliographystyle{chronological}
+% argument is your BibTeX string definitions and bibliography database(s)
+\bibliography{publicaciones}
+
+\end{document}


### PR DESCRIPTION
## Summary
- add crosslinks between CV pages
- translate Spanish CV to English and update `cv.md`
- provide English LaTeX source file
- place CV photo only in `cv/` folder
- update homepage with bilingual CV info

## Testing
- `bundle exec jekyll build` *(fails: bundler could not find jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_687a708ba8a4832e80a53e6bcbf96f4a